### PR TITLE
refactor: unify coordinate transformations under `rotation` and `transform` interface

### DIFF
--- a/src/cotrans/cotrans.jl
+++ b/src/cotrans/cotrans.jl
@@ -1,3 +1,30 @@
+# ── rotation: graph of frame-to-frame rotation matrices ───────────────────────
+export rotation, transform
+
+"""
+    rotation(from::Type{<:AbstractReferenceFrame}, to::Type{<:AbstractReferenceFrame}, t)
+
+Rotation matrix taking vectors from `from` to `to` reference frame at time `t`.
+
+Frames are passed as types (e.g. `rotation(GEI, GSM, t)`).
+
+Direct edges (`GEI↔GEO`, `GEI↔GSM`, `GSE↔GSM`, `GEO↔MAG`, `GSM↔SM`) are defined per pair; remaining pairs compose through hub frames. Inverses are obtained via `transpose`.
+"""
+function rotation end
+
+rotation(::Type{F}, ::Type{F}, t) where {F} = LinearAlgebra.I
+
+"""
+    transform(to, x, t)
+    transform(to, from, x, t)
+
+Transform `x` to reference frame `to` at time(s) `t`.
+
+`x` may be a vector, or a matrix of stacked vectors paired with either
+a scalar `t` or a vector `ts` (per-sample).
+"""
+function transform end
+
 include("geo2gei.jl")
 include("gei2gsm.jl")
 include("gse2gsm.jl")
@@ -27,43 +54,65 @@ const coord_pairs = (
     (:sm, :mag), (:mag, :sm),
 )
 
+const direct_edges = ((:GEO, :GEI), (:GSM, :GEI), (:GSM, :GSE), (:MAG, :GEO), (:SM, :GSM))
 
-gei2sm_mat(time) = gsm2sm_mat(time) * gei2gsm_mat(time)
-sm2gei_mat(time) = transpose(gei2sm_mat(time))
+# inverses of direct edges
+for (From, To) in direct_edges
+    @eval rotation(::Type{$From}, ::Type{$To}, t) = transpose(rotation($To, $From, t))
+end
 
-geo2gsm_mat(t) = gei2gsm_mat(t) * geo2gei_mat(t)
-gsm2geo_mat(t) = transpose(geo2gsm_mat(t))
+# chain transformations
+const chains = (
+    (:GEI, :GSM, :SM),
+    (:GEO, :GEI, :GSM),
+    (:GEO, :GEI, :SM),
+    (:GEI, :GEO, :MAG),
+    (:SM, :GEI, :MAG),
+)
 
-geo2sm_mat(t) = gei2sm_mat(t) * geo2gei_mat(t)
-sm2geo_mat(t) = transpose(geo2sm_mat(t))
+for chain in chains
+    @eval rotation(::Type{$(chain[1])}, ::Type{$(chain[3])}, t) =
+        rotation($(chain[2]), $(chain[3]), t) * rotation($(chain[1]), $(chain[2]), t)
+    @eval rotation(::Type{$(chain[3])}, ::Type{$(chain[1])}, t) = transpose(rotation($(chain[1]), $(chain[3]), t))
+end
 
-gei2mag_mat(t) = geo2mag_mat(t) * gei2geo_mat(t)
-mag2gei_mat(t) = transpose(gei2mag_mat(t))
+# ── transform methods (canonical: type-form) ──────────────────────────────────
 
-sm2mag_mat(t) = gei2mag_mat(t) * sm2gei_mat(t)
-mag2sm_mat(t) = transpose(sm2mag_mat(t))
+@inline transform(To, x::CoordinateVector{F}, t = x.t) where {F} =
+    transform(To, F, x, t)
 
+@inline function transform(To, From, x::CoordinateVector{F}, t) where {F}
+    @assert F == From
+    return To((rotation(From, To, t) * x)..., t)
+end
+
+@inline transform(To, From, x, t) = rotation(From, To, t) * x
+
+# matrix paths: vector ts is per-sample, anything else is a scalar time
+@inline function transform(To, From, A::AbstractMatrix, ts::AbstractVector; dims = 2)
+    return stack(eachslice(A; dims), ts; dims) do x, t
+        rotation(From, To, t) * x
+    end
+end
+
+@inline function transform(To, From, A::AbstractMatrix, t; dims = 2)
+    R = rotation(From, To, t)
+    return dims == 2 ? R * A : transpose(R * transpose(A))
+end
 
 coord_type(s::Symbol) = Symbol(uppercase(string(s)))
 for p in coord_pairs
     func = Symbol(p[1], "2", p[2])
-    matfunc = Symbol(func, :_mat)
+    T1, T2 = coord_type.(p)
 
     doc = """$(func)(x, t)
 
     Transforms coordinate(s) `x` from $(coord_text[p[1]]) to $(coord_text[p[2]]) reference frame at time(s) `t`.
+
+    Equivalent to [`transform`](@ref)`($T2, $T1, x, t)`.
     """
     @eval @doc $doc $func
-
-    @eval $func(x, t) = $matfunc(t) * x
-    T1, T2 = coord_type.(p)
-    @eval function $func(x::CoordinateVector, t)
-        @assert frame(x) == $T1()
-        return $T2(($matfunc(t) * x)..., t)
-    end
-    @eval @inline function $func(A::AbstractMatrix, times::AbstractVector; dims)
-        return stack($func, eachslice(A; dims), times; dims)
-    end
+    @eval @inline $func(x, t; kw...) = transform($T2, $T1, x, t; kw...)
     @eval export $func
 
     @eval $T2(x::CoordinateVector{$T1}, t = nothing) = $func(x, @something(t, x.t))

--- a/src/cotrans/gei2gsm.jl
+++ b/src/cotrans/gei2gsm.jl
@@ -1,21 +1,19 @@
 # https://github.com/PRBEM/IRBEM/blob/e7cecb00caf97bb6357f063d2ba1aa76d71a3705/source/init_nouveau.f#L438
 
 """
-    gei2gsm_mat(time)
+    rotation(GEI, GSM, time)
 
-Compute the GEI to GSM transformation matrix.
+GEI → GSM rotation matrix.
 
-First axis: sun direction (xS, yS, zS)
-Second axis: y-axis (cross product of dipole and sun, normalized)
-Third axis: z-axis (cross product of sun and y-axis, normalized)
+First axis: sun direction (xS, yS, zS).
+Second axis: cross product of dipole and sun, normalized.
+Third axis: cross product of sun and y-axis.
 """
-function gei2gsm_mat(time)
+function rotation(::Type{GEI}, ::Type{GSM}, time)
     gst, ra, dec = csundir(time)
-    dipole_gei = geo2gei_mat(gst) * calc_dipole_geo(time)
+    dipole_gei = rotation(GEO, GEI, gst) * calc_dipole_geo(time)
     v1 = calc_sun_gei(ra, dec)
     v2 = normalize(dipole_gei × v1)
     v3 = v1 × v2
     return transpose(hcat(v1, v2, v3))
 end
-
-gsm2gei_mat(x) = inv(gei2gsm_mat(x))

--- a/src/cotrans/geo2gei.jl
+++ b/src/cotrans/geo2gei.jl
@@ -1,10 +1,14 @@
 # https://pyspedas.readthedocs.io/en/latest/coords.html#pyspedas.cotrans_tools.cotrans_lib.subgeo2gei
 
-@inline function gei2geo_mat(gst)
+"""
+    rotation(GEI, GEO, gst_or_time)
+
+GEI → GEO rotation. Accepts either Greenwich sidereal time `gst` (radians) or
+an `AbstractTime` from which `gst` is derived.
+"""
+@inline function rotation(::Type{GEI}, ::Type{GEO}, gst)
     sgst, cgst = sincos(gst)
     return SA[cgst sgst 0; -sgst cgst 0; 0 0 1]
 end
 
-gei2geo_mat(time::AbstractTime) = gei2geo_mat(calculate_gst_alt(time))
-
-geo2gei_mat(x) = inv(gei2geo_mat(x))
+rotation(::Type{GEI}, ::Type{GEO}, time::AbstractTime) = rotation(GEI, GEO, calculate_gst_alt(time))

--- a/src/cotrans/geo2mag.jl
+++ b/src/cotrans/geo2mag.jl
@@ -1,29 +1,26 @@
 """
-    geo2mag_mat(time)
+    rotation(GEO, MAG, time)
 
-Compute the GEO to MAG transformation matrix.
-
-This follows Hapgood (1992) / UCL `geo_tran` convention:
+GEO → MAG rotation following Hapgood (1992) / UCL `geo_tran` convention:
 
 `T5 = <lat-90, Y> * <long, Z>`
 
 where `lat`/`long` are the dipole pole coordinates from the IGRF dipole terms.
-With dipole colatitude `θ = π/2 - lat` and dipole longitude `φ = long`, this can be written as `R_y(θ) * R_z(-φ)`.
+With dipole colatitude `θ = π/2 - lat` and dipole longitude `φ = long`, this
+factors as `R_y(θ) * R_z(-φ)`.
 """
-function geo2mag_mat(time)
+function rotation(::Type{GEO}, ::Type{MAG}, time)
     g, h = get_igrf_coeffs(time)
     θ, φ = @inbounds calc_dipole_angle(g[2], g[3], h[3])
     sθ, cθ = sincos(θ)
     sφ, cφ = sincos(φ)
 
-    # Transformation: R_y(θ) * R_z(-φ)
+    # R_y(θ) * R_z(-φ)
     # R_z(-φ) rotates dipole meridian to XZ plane
-    # R_y(θ) rotates dipole to align with Z-axis
+    # R_y(θ) aligns dipole with Z-axis
     return SA[
         cθ * cφ cθ * sφ -sθ
         -sφ cφ 0
         sθ * cφ sθ * sφ cθ
     ]
 end
-
-mag2geo_mat(time) = transpose(geo2mag_mat(time))

--- a/src/cotrans/gse2gsm.jl
+++ b/src/cotrans/gse2gsm.jl
@@ -1,27 +1,19 @@
 """
-    gse2gsm_mat(time)
+    rotation(GSE, GSM, time)
 
-Compute the GSE to GSM transformation matrix T3 = <- psi,X>, 
-where the rotation angle psi is the GSE-GSM angle.
+GSE → GSM rotation `T3 = <-ψ, X>`, where ψ is the GSE-GSM angle.
 
-This transformation is a rotation in the GSE YZ plane from the GSE Z axis to the GSM Z axis.
+A rotation in the GSE YZ plane that aligns the GSE Z axis with the GSM Z axis.
 """
-function gse2gsm_mat(time)
-    dipole_gei = geo2gei_mat(time) * calc_dipole_geo(time)
-    # Get sun direction parameters
+function rotation(::Type{GSE}, ::Type{GSM}, time)
+    dipole_gei = rotation(GEO, GEI, time) * calc_dipole_geo(time)
     _, sra, sdec, _, obliq = csundir(time)
     sun_gei = calc_sun_gei(sra, sdec)
-    # Calculate ecliptic pole direction in GEI
     pole_gei = SA[0.0, -sin(obliq), cos(obliq)]
 
-    # Calculate cross product of dipole and sun directions
     gmgs = cross(dipole_gei, sun_gei)
-    # Calculate magnitude of cross product
     rgmgs = norm(gmgs)
-    # Calculate cosine and sine of GSE-GSM angle
     cdze = dot(pole_gei, dipole_gei) / rgmgs
     sdze = dot(pole_gei, gmgs) / rgmgs
     return SA[1 0 0; 0 cdze sdze; 0 -sdze cdze]
 end
-
-gsm2gse_mat(time) = inv(gse2gsm_mat(time))

--- a/src/cotrans/gsm2sm.jl
+++ b/src/cotrans/gsm2sm.jl
@@ -2,22 +2,16 @@
 # Hapgood (1992): T4 = <-μ, Y> where μ is the dipole tilt angle
 
 """
-    gsm2sm_mat(time)
+    rotation(GSM, SM, time)
 
-Compute the GSM to SM transformation matrix.
-
-The transformation is a simple rotation around the Y-axis by the dipole tilt angle μ.
-GSM and SM share the same Y-axis (perpendicular to the dipole-sun plane).
+GSM → SM rotation: rotation around the shared Y-axis by the dipole tilt angle μ.
 """
-function gsm2sm_mat(time)
+function rotation(::Type{GSM}, ::Type{SM}, time)
     μ = dipole_tilt(time)
     sμ, cμ = sincos(μ)
-    # Rotation around Y-axis by μ
     return SA[
         cμ 0 -sμ
         0 1 0
         sμ 0 cμ
     ]
 end
-
-sm2gsm_mat(time) = transpose(gsm2sm_mat(time))

--- a/src/dipole.jl
+++ b/src/dipole.jl
@@ -56,7 +56,7 @@ function calc_dipole_geo(time)
     return SA[sθ * cφ, sθ * sφ, cθ]
 end
 
-calc_dipole_gei(time) = geo2gei_mat(time) * calc_dipole_geo(time)
+calc_dipole_gei(time) = rotation(GEO, GEI,time) * calc_dipole_geo(time)
 
 """
     dipole_tilt(time)
@@ -68,7 +68,7 @@ positive when the north magnetic pole is tilted toward the Sun.
 """
 function dipole_tilt(time)
     gst, ra, dec = csundir(time)
-    dipole_gei = geo2gei_mat(gst) * calc_dipole_geo(time)
+    dipole_gei = rotation(GEO, GEI,gst) * calc_dipole_geo(time)
     sun_gei = calc_sun_gei(ra, dec)
     # sin(μ) = dipole · sun
     return asin(dot(dipole_gei, sun_gei))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,13 +115,13 @@ end
 
 @testitem "geo2mag" begin
     using Dates
-    using GeoCotrans: geo2mag_mat, calc_dipole_geo, calc_dipole_angle, get_igrf_coeffs
+    using GeoCotrans: calc_dipole_geo, calc_dipole_angle, get_igrf_coeffs
 
     t = DateTime(2001, 1, 1, 2, 3, 4)
 
     # Test that dipole direction in MAG is along Z-axis
     dipole_geo = calc_dipole_geo(t)
-    dipole_mag = geo2mag_mat(t) * dipole_geo
+    dipole_mag = rotation(GEO, MAG, t) * dipole_geo
     @test dipole_mag ≈ [0, 0, 1]
 
     # Test CoordinateVector transformation
@@ -155,12 +155,12 @@ end
 
 @testitem "gsm2sm" begin
     using Dates
-    using GeoCotrans: gsm2sm_mat, sm2gsm_mat, dipole_tilt, gei2gsm_mat, calc_dipole_gei
+    using GeoCotrans: dipole_tilt, calc_dipole_gei
 
     t = DateTime(2001, 1, 1, 2, 3, 4)
-    M = gsm2sm_mat(t)
+    M = rotation(GSM, SM, t)
     # Test that dipole in GSM transforms to Z-axis in SM
-    dipole_gsm = gei2gsm_mat(t) * calc_dipole_gei(t)
+    dipole_gsm = rotation(GEI, GSM, t) * calc_dipole_gei(t)
     dipole_sm = M * dipole_gsm
     @test dipole_sm ≈ [0, 0, 1]
     # Verify dipole tilt angle is consistent with dipole in GSM
@@ -200,6 +200,71 @@ end
     geo = GEO(1.0, 2.0, 3.0, t)
     @test SM(geo) ≈ SM(GEI(geo))
     @test GEO(SM(geo)) ≈ geo
+end
+
+@testitem "rotation graph" begin
+    using Dates
+    using LinearAlgebra
+
+    t = DateTime(2001, 1, 1, 2, 3, 4)
+
+    # identity
+    @test rotation(GEI, GEI, t) == I
+    @test rotation(GSM, GSM, t) == I
+
+    # inverse via transpose round-trips to identity (direct edges)
+    for (F1, F2) in ((GEI, GSM), (GSE, GSM), (GEO, MAG), (GSM, SM), (GEI, GEO))
+        R = rotation(F1, F2, t)
+        @test R * rotation(F2, F1, t) ≈ I
+        @test rotation(F2, F1, t) ≈ transpose(R)
+    end
+
+    # all chain pairs round-trip to identity
+    for (F1, F2) in ((GEI, SM), (GEO, GSM), (GEO, SM), (GEI, MAG), (SM, MAG))
+        @test rotation(F1, F2, t) * rotation(F2, F1, t) ≈ I
+    end
+end
+
+@testitem "transform interface" begin
+    using Dates
+    using LinearAlgebra
+
+    t = DateTime(2001, 1, 1, 2, 3, 4)
+    R = rotation(GEI, GSM, t)
+
+    # raw vector with explicit (to, from)
+    x = [1.0, 2.0, 3.0]
+    @test transform(GSM, GEI, x, t) ≈ R * x
+
+    # CoordinateVector: frame inferred, t inferred
+    gei = GEI(1.0, 2.0, 3.0, t)
+    gsm = transform(GSM, gei)
+    @test gsm isa CoordinateVector{GSM}
+    @test gsm ≈ gei2gsm(gei, t)
+    @test gsm.t == t
+
+    # CoordinateVector with explicit t override
+    @test transform(GSM, gei, t) ≈ gsm
+
+    # frame mismatch is caught
+    @test_throws AssertionError transform(GSM, GSE, gei, t)
+
+    # identity
+    @test transform(GEI, GEI, x, t) ≈ x
+    @test transform(GEI, gei) ≈ gei
+
+    # matrix path: scalar time builds rotation once
+    A = rand(3, 5)
+    @test transform(GSM, GEI, A, t) ≈ R * A
+
+    # matrix path: per-sample times
+    ts = [t + Hour(i) for i in 0:4]
+    B = transform(GSM, GEI, A, ts; dims = 2)
+    @test B ≈ gei2gsm(A, ts; dims = 2)
+
+    # matrix path: dims = 1
+    A1 = permutedims(A)
+    @test transform(GSM, GEI, A1, ts; dims = 1) ≈ permutedims(B)
 end
 
 @testitem "Aqua" begin


### PR DESCRIPTION
Replace individual `*2*_mat` functions with a unified `rotation(From, To, t)` interface that computes frame-to-frame rotation matrices
