### PR TITLE
fix: remove time field from CoordinateVector and require explicit time arguments

### DIFF
--- a/src/FieldModels/transform.jl
+++ b/src/FieldModels/transform.jl
@@ -17,7 +17,7 @@ from_cartesian(::Cartesian3, B, r) = B
 from_cartesian(::Geodetic, B, r) = car2enu(B, r)
 
 function transform_to(::F0, ::F1, pos, t) where {F0, F1}
-    return F0 == F1 ? pos : F1(F0(pos), t)
+    return F0 == F1 ? pos : transform(F1, F0, pos, t)
 end
 
 function transform_position(f0, r0, f1, r1, 𝐫, t)

--- a/src/cotrans/cotrans.jl
+++ b/src/cotrans/cotrans.jl
@@ -78,12 +78,12 @@ end
 
 # ── transform methods (canonical: type-form) ──────────────────────────────────
 
-@inline transform(To, x::CoordinateVector{F}, t = x.t) where {F} =
+@inline transform(To, x::CoordinateVector{F}, t) where {F} =
     transform(To, F, x, t)
 
 @inline function transform(To, From, x::CoordinateVector{F}, t) where {F}
     @assert F == From
-    return To((rotation(From, To, t) * x)..., t)
+    return To((rotation(From, To, t) * x)...)
 end
 
 @inline transform(To, From, x, t) = rotation(From, To, t) * x
@@ -116,8 +116,6 @@ for p in coord_pairs
     @eval @doc $doc $func
     @eval @inline $func(x, t; kw...) = transform($T2, $T1, x, t; kw...)
     @eval export $func
-
-    @eval $T2(x::CoordinateVector{$T1}, t = nothing) = $func(x, @something(t, x.t))
 end
 
 pair2func(p) = getfield(GeoCotrans, Symbol(p[1], "2", p[2]))

--- a/src/gdz.jl
+++ b/src/gdz.jl
@@ -8,7 +8,7 @@ Geodetic coordinate system with:
 
 https://www.wikipedia.org/wiki/Geodetic_coordinates
 """
-GDZ(ϕ, λ, h = 0, t = nothing) = CoordinateVector{GEO, Geodetic}(ϕ, λ, h, t)
+GDZ(ϕ, λ, h = 0) = CoordinateVector{GEO, Geodetic}(ϕ, λ, h)
 GDZ() = GEO(), Geodetic()
 getcsys(::typeof(GDZ)) = GDZ()
 

--- a/src/mlt.jl
+++ b/src/mlt.jl
@@ -10,12 +10,10 @@ MLT is computed from the difference between the magnetic longitudes of the posit
 - [IRBEM implementation](https://github.com/IRBEM/IRBEM/blob/5c2c6c2/src/geo_tran.f)
 """
 @inline function get_mlt(xGEO, time)
-    x_geo = GEO(xGEO, time)
-    x_mag = MAG(x_geo)
-    mlon_pos = φ(x_mag)
+    mlon_pos = φ(geo2mag(GEO(xGEO), time))
 
     x_sun_gei = calc_sun_gei(time)
-    x_sun_mag = MAG(GEO(GEI(x_sun_gei, time)))
+    x_sun_mag = gei2mag(x_sun_gei, time)
     mlon_sun = φ(x_sun_mag)
 
     mlt = rad2deg(mlon_pos - mlon_sun) / 15 + 12

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,54 +3,42 @@ using StaticArrays: Size
 include("FieldModels/FieldModels.jl")
 
 """
-    CoordinateVector{F, T}
+    CoordinateVector{F, R}
 
 3-element `FieldVector` in a specific coordinate frame `F` using representation `R`.
 """
-struct CoordinateVector{F, R, T, T2} <: FieldVector{3, T}
+struct CoordinateVector{F, R, T} <: FieldVector{3, T}
     x::T
     y::T
     z::T
-    t::T2
 end
 
-function CoordinateVector{F, R}(x::T, y::T, z::T, t::T2 = nothing) where {F, R, T, T2}
-    return CoordinateVector{F, R, T, T2}(x, y, z, t)
+function CoordinateVector{F, R}(x::T, y::T, z::T) where {F, R, T}
+    return CoordinateVector{F, R, T}(x, y, z)
 end
 
-CoordinateVector{F}(x, y, z, t = nothing) where {F} = CoordinateVector{F, Cartesian3}(x, y, z, t)
-CoordinateVector{F, R}(x, y, z, t = nothing) where {F, R} =
-    CoordinateVector{F, R}(promote(x, y, z)..., t)
-CoordinateVector{F, R, T}(x::T, y::T, z::T) where {F, R, T} =
-    CoordinateVector{F, R, T, Nothing}(x, y, z, nothing)
-
-# StaticArrays tries to call that type with 3 arguments (x, y, z)
-# I do not know how to carry time information forward when doing operations like Matrix multiplication
-# So default time to nothing for now :(
-StaticArrays.similar_type(::Type{CoordinateVector{C, R, T1, TT}}, ::Type{T2}, ::Size) where {C, R, T1, TT, T2} =
+CoordinateVector{F}(x, y, z) where {F} = CoordinateVector{F, Cartesian3}(x, y, z)
+CoordinateVector{F, R}(x, y, z) where {F, R} =
+    CoordinateVector{F, R}(promote(x, y, z)...)
+StaticArrays.similar_type(::Type{CoordinateVector{C, R, T1}}, ::Type{T2}, ::Size) where {C, R, T1, T2} =
     CoordinateVector{C, R, T2}
 
 for sys in (:GEI, :GEO, :GSM, :GSE, :MAG, :SM)
     doc = """$(FrameDescriptions[sys])
 
     $(get(FrameDefinitions, sys, ""))
-
-    To Construct a [`CoordinateVector`](@ref) in `$sys` reference frame with cartesian representation.
-
-        $sys(x, y, z, t = nothing)
-        $sys(𝐫, t = nothing)
     """
 
     @eval begin
         struct $sys <: AbstractReferenceFrame end
         @doc $doc $sys
-        $sys(x, y, z, t = nothing) = CoordinateVector{$sys}(x, y, z, t)
-        function $sys(𝐫, t = nothing)
+        $sys(x, y, z) = CoordinateVector{$sys}(x, y, z)
+        function $sys(𝐫)
             @assert length(𝐫) == 3
             # check when frame is specified
             f = frame(𝐫)
             !isnothing(f) && @assert f isa $sys
-            return CoordinateVector{$sys}(𝐫[1], 𝐫[2], 𝐫[3], t)
+            return CoordinateVector{$sys}(𝐫[1], 𝐫[2], 𝐫[3])
         end
         export $sys
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,12 +28,7 @@ end
 
     𝐫 = GDZ(0, 60, 5)
     @test getcsys(𝐫) == getcsys(GDZ) == (GEO(), Geodetic())
-    @test 𝐫 .* 2.0 isa CoordinateVector{GEO, Geodetic}
-
-    t = Date(2021, 3, 28)
-    𝐫_t = GDZ(0, 60, 5, t)
-    @test getcsys(𝐫_t) == getcsys(GDZ)
-    @test (𝐫_t .* 2.0).t == nothing
+    @test 𝐫 .* 2.0 isa GeoCotrans.CoordinateVector{GEO, Geodetic}
     @test representation(𝐫) == Geodetic()
 end
 
@@ -42,14 +37,11 @@ end
     using DimensionalData
 
     t = Date(2021, 1, 1)
-    gse = GSE(1, 2, 3)
-    gse_t = GSE(1, 2, 3, t)
+    gse = [1, 2, 3]
     gsm = gse2gsm(gse, t)
-    @test gsm isa CoordinateVector{GSM}
-    @test gsm.t == t
-    @test GSM(gse, t) === gsm
-    @test GSM(gse_t) === gsm
-    @test_throws AssertionError gse2gsm(GSM(1, 2, 3), t)
+    @test gsm isa AbstractVector
+    @test size(gsm) == (3,)
+    @test_throws AssertionError gse2gsm(GeoCotrans.CoordinateVector{GSM, Cartesian3}(1, 2, 3), t)
 
     # Test GSE->GSM transformation
     # Data from Python test case
@@ -125,13 +117,11 @@ end
     @test dipole_mag ≈ [0, 0, 1]
 
     # Test CoordinateVector transformation
-    geo = GEO(2.8011944117533565, -2.4048913761357267, 4.5066403602406275)
-    geo_t = GEO(geo, t)
+    geo = [2.8011944117533565, -2.4048913761357267, 4.5066403602406275]
     mag = geo2mag(geo, t)
     r_mag = [2.298686529948157, 1.8997853069109853, 5.004683409035982]
     @test mag ≈ r_mag
-    @test MAG(geo, t) === MAG(geo_t) === mag
-    @test GEO(MAG(geo_t)) ≈ geo_t
+    @test mag2geo(mag, t) ≈ geo
 end
 
 @testitem "mlt" begin
@@ -150,7 +140,7 @@ end
     da = DimArray(A, (Ti(times), Y(1:3)))
     @test get_mlt(da) ≈ get_mlt(A, times; dim = 1)
 
-    @info @b get_mlt($r, $t)
+    @test (@b get_mlt($r, $t)).allocs == 0
 end
 
 @testitem "gsm2sm" begin
@@ -168,14 +158,13 @@ end
     @test dipole_gsm ≈ [sin(μ), 0, cos(μ)]
 
     # Test CoordinateVector transformation
-    gsm = GSM(-5.1, 0.3, 2.8)
-    gsm_t = GSM(gsm, t)
+    gsm = [-5.1, 0.3, 2.8]
     sm = gsm2sm(gsm, t)
-    sm_geopack_true = SM(-2.9670092644479498, 0.3, 5.004683409035982, t)
+    sm_geopack_true = [-2.9670092644479498, 0.3, 5.004683409035982]
     @test sm ≈ sm_geopack_true rtol = 1.0e-7
-    @test SM(gsm_t) === SM(gsm, t) === gsm2sm(gsm, t)
+    @test sm2gsm(sm, t) ≈ gsm
     # Test roundtrip transformation
-    @test GSM(SM(gsm_t)) ≈ gsm_t
+    @test gsm2sm(sm2gsm(sm, t), t) ≈ sm
 end
 
 # The most expensive transformation
@@ -185,21 +174,20 @@ end
     using Dates
 
     t = DateTime(2001, 1, 1, 2, 3, 4)
-    mag = MAG(1.0, 2.0, 3.0, t)
+    mag = [1.0, 2.0, 3.0]
     sm = mag2sm(mag, t)
 
     @info @b mag2sm($mag, $t)
-    @test MAG(SM(mag)) ≈ mag
-    @test MAG(GEI(mag)) ≈ mag
+    @test sm2mag(sm, t) ≈ mag
+    @test gei2mag(mag2gei(mag, t), t) ≈ mag
 end
 
 @testitem "geo2sm" begin
     using Dates
 
     t = DateTime(2001, 1, 1, 2, 3, 4)
-    geo = GEO(1.0, 2.0, 3.0, t)
-    @test SM(geo) ≈ SM(GEI(geo))
-    @test GEO(SM(geo)) ≈ geo
+    geo = [1.0, 2.0, 3.0]
+    @test sm2geo(geo2sm(geo, t), t) ≈ geo
 end
 
 @testitem "rotation graph" begin
@@ -236,14 +224,12 @@ end
     x = [1.0, 2.0, 3.0]
     @test transform(GSM, GEI, x, t) ≈ R * x
 
-    # CoordinateVector: frame inferred, t inferred
-    gei = GEI(1.0, 2.0, 3.0, t)
-    gsm = transform(GSM, gei)
-    @test gsm isa CoordinateVector{GSM}
+    # CoordinateVector: frame inferred via internal vector type
+    gei = GeoCotrans.CoordinateVector{GEI, Cartesian3}(1.0, 2.0, 3.0)
+    gsm = transform(GSM, gei, t)
+    @test gsm isa GeoCotrans.CoordinateVector{GSM, Cartesian3}
     @test gsm ≈ gei2gsm(gei, t)
-    @test gsm.t == t
 
-    # CoordinateVector with explicit t override
     @test transform(GSM, gei, t) ≈ gsm
 
     # frame mismatch is caught
@@ -251,7 +237,7 @@ end
 
     # identity
     @test transform(GEI, GEI, x, t) ≈ x
-    @test transform(GEI, gei) ≈ gei
+    @test transform(GEI, gei, t) ≈ gei
 
     # matrix path: scalar time builds rotation once
     A = rand(3, 5)


### PR DESCRIPTION
- Change all coordinate transformation functions to require explicit time parameter
